### PR TITLE
Refactor build system and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This is basically a wrapper script for `ffmpeg` that I use regularly, mostly to quickly edit dog photos and videos... no seriously.
 
+This script has been written for and only tested on Windows with an NVIDIA GPU.
+
 __Commands:__
 
 * `media-tool clipify` - Reduce framerate by half if over 45fps (NVENC)
@@ -17,12 +19,14 @@ __Commands:__
 
 All commands support `--help` for usage details.
 
-## Build Dependencies
+## Requirements
 
-* [uv](https://docs.astral.sh/uv/) — required to run the build script (uses `uvx`)
+* Python 3.14+
+* `ffmpeg.exe` and `ffprobe.exe` in your `%PATH%`
+* Python dependencies listed in `requirements.txt` — install with `pip install -r requirements.txt`
 
-## Installation
+## Build
 
-_Technically_ this is all portable Python but I only really care about Windows, therefore there's a simple `build.bat` script that will build the script into a single `media-tool.exe`. Also assumes you have `ffmpeg.exe` and `ffprobe.exe` somewhere in your `%PATH%`.
+Requires [uv](https://docs.astral.sh/uv/) (uses `uvx` to run PyInstaller).
 
-For development/direct use, the script supports [`uv`](https://github.com/astral-sh/uv) via its inline script metadata — just run `uv run media-tool.py <command>`.
+Run `build.bat` to build into a single `media-tool.exe`.

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,2 @@
+pip install -r requirements.txt
 uvx pyinstaller --onefile --name media-tool media-tool.py

--- a/media-tool.py
+++ b/media-tool.py
@@ -1,11 +1,3 @@
-#!/usr/bin/env -S uv run --script
-# -*- mode: python -*-
-# /// script
-# requires-python = ">=3.14"
-# dependencies = [
-#     "ffmpeg-python",
-# ]
-# ///
 import sys
 import argparse
 from os import path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ffmpeg-python


### PR DESCRIPTION
This PR refactors the project's build and dependency management system while updating documentation to clarify requirements and setup instructions.

## Summary
The inline script metadata has been removed from `media-tool.py` in favor of a traditional `requirements.txt` file, and the build process has been updated to explicitly install dependencies before building the executable. Documentation has been reorganized to better distinguish between runtime requirements and build instructions.

## Key Changes
- **Removed inline script metadata** from `media-tool.py` (the `uv run --script` shebang and PEP 723 script block) to simplify the main script file
- **Created `requirements.txt`** to explicitly declare the `ffmpeg-python` dependency
- **Updated `build.bat`** to install dependencies via `pip install -r requirements.txt` before running PyInstaller
- **Reorganized README.md**:
  - Renamed "Build Dependencies" section to "Requirements" for clarity
  - Separated runtime requirements (Python 3.14+, ffmpeg/ffprobe, pip dependencies) from build requirements (uv)
  - Renamed "Installation" section to "Build" and simplified instructions
  - Added platform-specific note that the script is Windows/NVIDIA GPU-focused

## Implementation Details
The refactoring moves from a self-contained script approach (using uv's inline script metadata) to a more conventional Python project structure with explicit dependency management. This makes the project easier to understand for developers unfamiliar with uv's script features while maintaining the same functionality.

https://claude.ai/code/session_018ByaNsye1Cb9iQ1NPECpBb